### PR TITLE
makefile tp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Build and dependencies
+
+# Systèmes de build - TP1: makefile
+
+## Préambule
+
+Ecrire un makefile, dont le travail est de manipuler des fichiers .dot et de les
+transformer en .png
+
+DOT est un langage qui permet de définir des graphes, c'est à dire un ensemble
+de noeuds et de relations
+
+Pour installer make
+
+    apt-get update
+    apt-get install make
+
+Pour installer dot
+
+    apt-get update
+    apt-get install graphviz
+
+
+## A. Convertir un .dot en .png
+
+Ecrire une _cible_ `build` qui convertir le fichier `graph.dot` en `graph.png`
+
+Rappel: la commande pour convertir un .dot en .png est la suivante:
+
+    dot graph.dot -Tpng > graph.png
+
+## B. Lister les fichiers .dot
+
+Ecrire une _cible_ `list` qui liste tous les fichiers `.dot` du dossier courant
+
+Note: vous pouvez utiliser l'instruction `wildcard` pour remplir une variable
+
+## C. Lister les fichiers .png
+
+Ecire une _cible_ `destlist` qui liste tous les fichiers `.png` qui devront
+être produit depuis les `.dot` 
+
+Note: vous pouvez utiliser l'instruction `patsubst` pour réécrire le contenu
+d'une variable
+
+## D. Convertir un .dot en .png (bis)
+
+Ecrire une _cible_ générique `%.png` (qui prend en entrée un .dot) et qui
+génère le fichier png ciblé
+
+## E. Améliorer build
+
+Adaptez la _cible_ `build` pour utiliser la règle générique plutot que d'agir
+sur un unique fichier.

--- a/TpOne/Makefile
+++ b/TpOne/Makefile
@@ -1,0 +1,16 @@
+dotFiles =$(wildcard *.dot) 
+pngFiles = $(patsubst % .dot , %.png,  $(dotFiles))
+
+build:  $(pngFiles)
+
+list: 
+	@echo $(dotFiles)
+
+destlist:
+	@echo $(pngFiles)
+
+%.png: %.dot
+	dot  $<  -Tpng >  $@
+
+clean:
+	rm *.png

--- a/TpOne/Makefile
+++ b/TpOne/Makefile
@@ -10,7 +10,7 @@ destlist:
 	@echo $(PNGFILES)
 
 %.png: %.dot
-	dot  $<  -Tpng >  $@
+	dot -Tpng $< > $@
 
 clean:
 	rm *.png

--- a/TpOne/Makefile
+++ b/TpOne/Makefile
@@ -1,13 +1,13 @@
-dotFiles =$(wildcard *.dot) 
-pngFiles = $(patsubst % .dot , %.png,  $(dotFiles))
+DOTFILES =$(wildcard *.dot) 
+PNGFILES = $(patsubst % .dot , %.png,  $(DOTFILES))
 
-build:  $(pngFiles)
+build:  $(PNGFILES)
 
 list: 
-	@echo $(dotFiles)
+	@echo $(DOTFILES)
 
 destlist:
-	@echo $(pngFiles)
+	@echo $(PNGFILES)
 
 %.png: %.dot
 	dot  $<  -Tpng >  $@

--- a/TpThree/Makefile
+++ b/TpThree/Makefile
@@ -1,0 +1,35 @@
+## On souhaite avoir l'arborescence suivante
+# .
+# |- hello
+# |   |- lib.c
+# |   `- main.c
+# `- hello2
+#     `- world.c
+#
+## On souhaite générer les binaires suivants
+# - build/hello à partir du dossier hello
+# - build/world à partir du dossier hello2
+
+PROGRAMS=hello world again
+
+hello_BIN=hello
+hello_DIR=hello
+hello_FILES=main.c lib.c
+
+world_BIN=world
+world_DIR=hello2
+world_FILES=world.c
+
+again_BIN=again
+again_DIR=hello3
+again_FILES=world.c
+
+include magic.mk
+
+zip:
+	zip -r $$(basename $$(pwd)).zip .
+
+zip_clean: 
+	rm -f $$(basename $$(pwd)).zip
+
+clean: zip_clean

--- a/TpThree/hello/lib.c
+++ b/TpThree/hello/lib.c
@@ -1,0 +1,4 @@
+int answer_to_universe_and_everything() {
+	return 42;
+}
+

--- a/TpThree/hello/lib.h
+++ b/TpThree/hello/lib.h
@@ -1,0 +1,2 @@
+
+int answer_to_universe_and_everything();

--- a/TpThree/hello/main.c
+++ b/TpThree/hello/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+#include "lib.h"
+
+int main(int argc, char** argv) {
+	
+	printf("Hello world %d\n", answer_to_universe_and_everything());
+	return 0;
+}

--- a/TpThree/hello2/world.c
+++ b/TpThree/hello2/world.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+	printf("Hello world\n");
+	return 0;
+}

--- a/TpThree/hello3/world.c
+++ b/TpThree/hello3/world.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+	printf("Hello world\n");
+	return 0;
+}

--- a/TpThree/magic.mk
+++ b/TpThree/magic.mk
@@ -1,0 +1,57 @@
+## Rappel makefile
+# a: b c d e
+# 	$@  => a
+# 	$<  => b
+# 	$^  => b c d e
+# 	$$  => $
+
+#
+## On se souvient que pour compiler du C, ça se passe dans cet ordre là
+#
+# SRC   OBJ   BIN
+# .c => .o => bin
+#
+## On aura surement les dépendances suivantes
+
+# hello_FILES= ...
+# hello_OBJS=$(patsubst %.c,%.o,$(hello_FILES))
+#
+# hello/%.o: hello/%.c
+#     gcc -c -o ...
+#
+# build/hello: $(hello_OBJS)
+#     gcc -o ...
+
+
+## DANGER= si je fais $($(1)_truc)) => make va mal comprendre le contenu
+## TECHNIQue/ASTUCE
+##  $$( ) => pas interprété a la premiere passe
+##  $( ) => interprété à la premiere passe
+
+# bloc de code avec target_BIN , target_DIR, target_FILES
+# * remplacer les $ par des $$
+# * remplacer target_ par $(1)_
+
+define PROGRAM_tpl
+$(1)_FILES_WITH_DIR=$$(addprefix $$($(1)_DIR)/,$$($(1)_FILES))
+$(1)_OBJS=$$(patsubst %.c,%.o,$$($(1)_FILES_WITH_DIR))
+
+$$($(1)_DIR)/%.o: $$($(1)_DIR)/%.c
+	gcc -c -o $$@ $$<
+
+build/$$($(1)_BIN): $$($(1)_OBJS)
+	mkdir -p build
+	gcc -o $$@ $$^
+
+$(1)_clean:
+	rm -f build/$$($(1)_BIN)
+	rm -f $$($(1)_OBJS)
+
+clean: $(1)_clean
+
+build: build/$$($(1)_BIN)
+
+endef
+
+$(foreach group,$(PROGRAMS),$(eval $(call PROGRAM_tpl,$(group))))
+

--- a/TpTwo/Makefile
+++ b/TpTwo/Makefile
@@ -1,0 +1,9 @@
+DOT_FILES =$(wildcard *.dot) 
+PNG_FILES = $(patsubst % .dot , %.dot.png,  $(DOTFILES))
+
+all:
+	@echo "Hello world"
+
+build: $(PNG_FILES )
+
+include dot.mk

--- a/TpTwo/dot.mk
+++ b/TpTwo/dot.mk
@@ -1,0 +1,2 @@
+%.dot.png: %.dot
+	dot -Tpng $< > $@


### PR DESCRIPTION
# Systèmes de build - TP1: makefile

## Préambule

Ecrire un makefile, dont le travail est de manipuler des fichiers .dot et de les
transformer en .png

DOT est un langage qui permet de définir des graphes, c'est à dire un ensemble
de noeuds et de relations

Pour installer make

    apt-get update
    apt-get install make

Pour installer dot

    apt-get update
    apt-get install graphviz


## A. Convertir un .dot en .png

Ecrire une _cible_ `build` qui convertir le fichier `graph.dot` en `graph.png`

Rappel: la commande pour convertir un .dot en .png est la suivante:

    dot graph.dot -Tpng > graph.png

## B. Lister les fichiers .dot

Ecrire une _cible_ `list` qui liste tous les fichiers `.dot` du dossier courant

Note: vous pouvez utiliser l'instruction `wildcard` pour remplir une variable

## C. Lister les fichiers .png

Ecire une _cible_ `destlist` qui liste tous les fichiers `.png` qui devront
être produit depuis les `.dot` 

Note: vous pouvez utiliser l'instruction `patsubst` pour réécrire le contenu
d'une variable

## D. Convertir un .dot en .png (bis)

Ecrire une _cible_ générique `%.png` (qui prend en entrée un .dot) et qui
génère le fichier png ciblé

## E. Améliorer build

Adaptez la _cible_ `build` pour utiliser la règle générique plutot que d'agir
sur un unique fichier.

# Systèmes de build - TP2: makefile template 

# Systèmes de build - TP3: makefile template with C code